### PR TITLE
added composer autoloader (fixes #4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
     "issues": "https://github.com/PyYoshi/shortuuid-php/issues",
     "source": "https://github.com/PyYoshi/shortuuid-php/"
   },
+  "autoload": {
+    "classmap": ["src/ShortUUID"]
+  },
   "require": {
     "php": ">=5.6",
     "ramsey/uuid": "^3.5.1",

--- a/src/ShortUUID/Autoloader.php
+++ b/src/ShortUUID/Autoloader.php
@@ -2,6 +2,9 @@
 
 namespace ShortUUID;
 
+/**
+ * @deprecated Use composer autoloader instead.
+ */
 class Autoloader
 {
     const NAME_SPACE = 'ShortUUID';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,5 @@
 <?php
+
 error_reporting(E_ALL);
 
-require dirname(__DIR__) . "/vendor/autoload.php";
-require_once dirname(__DIR__) . '/src/ShortUUID/Autoloader.php';
-\ShortUUID\Autoloader::register();
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
After installing this library using composer class autoloading is not working properly.
The library contains its own autoloading class that needs to be included manually.

This PR fixes this issue and does the following:
- adds a classmap autoloading to composer.json
- deprecates `Autoloader.php` (cannot be removed as some people might be using it)
- removed `Autoloader.php` in phpunit's `bootstrap.php` 